### PR TITLE
fix: support plain text

### DIFF
--- a/example/react-example/package-lock.json
+++ b/example/react-example/package-lock.json
@@ -7207,7 +7207,6 @@
       "version": "file:../..",
       "requires": {
         "color-name": "^1.1.4",
-        "escape-html": "^1.0.3",
         "html-to-vdom": "^0.7.0",
         "image-size": "^0.8.3",
         "jszip": "^3.5.0",
@@ -9726,11 +9725,6 @@
             "is-date-object": "^1.0.1",
             "is-symbol": "^1.0.2"
           }
-        },
-        "escape-html": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "escape-string-regexp": {
           "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@oozcitak/dom": "1.15.6",
         "@oozcitak/util": "8.3.4",
         "color-name": "^1.1.4",
-        "escape-html": "^1.0.3",
         "html-to-vdom": "^0.7.0",
         "image-size": "^1.0.0",
         "image-to-base64": "^2.2.0",
@@ -2320,11 +2319,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -8546,11 +8540,6 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@oozcitak/util": "8.3.4",
     "@oozcitak/dom": "1.15.6",
     "color-name": "^1.1.4",
-    "escape-html": "^1.0.3",
     "html-to-vdom": "^0.7.0",
     "image-size": "^1.0.0",
     "image-to-base64": "^2.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import * as meta from './package.json';
 
 export default {
   input: 'index.js',
-  external: ['color-name', 'escape-html', 'html-to-vdom', 'jszip', 'virtual-dom', 'xmlbuilder2'],
+  external: ['color-name', 'html-to-vdom', 'jszip', 'virtual-dom', 'xmlbuilder2'],
   plugins: [
     resolve(),
     json(),

--- a/src/helpers/render-document-file.js
+++ b/src/helpers/render-document-file.js
@@ -7,7 +7,6 @@ import isVNode from 'virtual-dom/vnode/is-vnode';
 import isVText from 'virtual-dom/vnode/is-vtext';
 // eslint-disable-next-line import/no-named-default
 import { default as HTMLToVDOM } from 'html-to-vdom';
-import escape from 'escape-html';
 import sizeOf from 'image-size';
 import imageToBase64 from 'image-to-base64';
 import mimeTypes from 'mime-types';
@@ -316,7 +315,7 @@ export async function convertVTreeToXML(docxDocumentInstance, vTree, xmlFragment
   } else if (isVNode(vTree)) {
     await findXMLEquivalent(docxDocumentInstance, vTree, xmlFragment);
   } else if (isVText(vTree)) {
-    xmlBuilder.buildTextElement(xmlFragment, escape(String(vTree.text)));
+    xmlFragment.import(await xmlBuilder.buildParagraph(vTree, {}, docxDocumentInstance));
   }
   return xmlFragment;
 }


### PR DESCRIPTION
The piece of code that was supposed to generate a plain text fragment was calling buildTextElement (which doesn't work) but not even with the right arguments: (xmlFragment, text) instead of (text)!

This feature is obviously not maintained but we need it.

The escape-html dependency is now unused, which is very surprising. The commit introducing it didn't give any explanation.