### PR TITLE
chore(release): v1.6.4-hyperlex.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-to-docx",
-  "version": "1.6.4",
+  "version": "1.6.4-hyperlex.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "html-to-docx",
-      "version": "1.6.4",
+      "version": "1.6.4-hyperlex.1",
       "license": "MIT",
       "dependencies": {
         "@oozcitak/dom": "1.15.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-docx",
-  "version": "1.6.4",
+  "version": "1.6.4-hyperlex.1",
   "description": "HTML to DOCX converter",
   "keywords": [
     "html",
@@ -19,8 +19,7 @@
     "lint": "eslint --fix .",
     "prettier:check": "prettier --check '**/*.{js}'",
     "validate": "run-s lint prettier:check",
-    "build": "rollup -c",
-    "prepare": "husky install"
+    "build": "rollup -c"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
there is a race condition in the prepare script that makes yarn install fail randomy when fetching packages from clm-api

cf https://github.com/yarnpkg/yarn/issues/7212